### PR TITLE
English labels expected while parsing response for 'svn info' command

### DIFF
--- a/isotoma/recipe/facts/__init__.py
+++ b/isotoma/recipe/facts/__init__.py
@@ -82,7 +82,7 @@ class Facts(object):
         if os.path.exists(os.path.join(vcs_dir, ".svn")):
             self.options["vcs.type"] = "svn"
 
-            p = subprocess.Popen(["svn", "info", vcs_dir], stdout=subprocess.PIPE)
+            p = subprocess.Popen(["svn", "info", vcs_dir], stdout=subprocess.PIPE, env={'LC_MESSAGES':'en_GB'})
             s, e = p.communicate()
 
             for line in s.split("\n"):


### PR DESCRIPTION
Hi, I'm using your product, but becouse I have polish locales set by default in my system settings - I get an error when the 'svn info' command is executed and the result messages are expected to be in english language. I commited a fix for explicitely setting english locales while executing this command.
Please consider including my fix.
